### PR TITLE
Fix running inside a container, minor app fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ project/myapp.db
 project/config.py
 venv
 Web_Blog.iml
-project/.env
+*.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,15 @@ WORKDIR /app
 COPY project/requirements.txt .
 RUN pip install -r requirements.txt
 
+# Move the container's entrypoint to reuse it
+RUN mv /entrypoint.sh /uwsgi-nginx-flask-entrypoint.sh
+# Copy our entrypoint
+COPY project/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 COPY project/ .
 
 EXPOSE 80
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/start.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,13 +11,6 @@ services:
       context: .
     ports:
       - 3000:80
-    volumes:
-      - ./db:/app/db
-    environment:
-      FLASK_APP: main
-#    command:
-#      - dos2unix
-#      - entrypoint.sh
     depends_on:
       - pg
 

--- a/project/config.py
+++ b/project/config.py
@@ -1,4 +1,4 @@
-API_KEY='dfasfj9wer@45635sdG#!#TAY&()@$VCb3563rsdgfsa#$%34'
+SECRET_KEY = 'dfasfj9wer@45635sdG#!#TAY&()@$VCb3563rsdgfsa#$%34'
 
 # Postgres settings
 # POSTGRES_HOST = os.environ.get('POSTGRES_HOST')

--- a/project/entrypoint.sh
+++ b/project/entrypoint.sh
@@ -1,4 +1,7 @@
-#!/usr/bin/env bash
+#! /usr/bin/env sh
+set -e
+
+/uwsgi-nginx-flask-entrypoint.sh
 
 python create_models.py
 

--- a/project/main.py
+++ b/project/main.py
@@ -94,9 +94,7 @@ def logout():
 @app.route('/index.html')
 def index():
     posts = Session.query(Post).all()
-    username = current_user.username if current_user.is_authenticated else None
-    return render_template('index.html', posts=posts,
-                           is_authed=current_user.is_authenticated, username=username)
+    return render_template('index.html', posts=posts)
 
 
 @app.route('/new_post.html', methods=("GET", "POST"))

--- a/project/static/hf.css
+++ b/project/static/hf.css
@@ -21,8 +21,9 @@ a {
 text-decoration: none; color: #FFF;
 }
 
-a: hover {
-text-decoration: none; color: #FFF;
+a:hover {
+  text-decoration: none;
+  color: #FFF;
 }
 
 h2{

--- a/project/templates/index.html
+++ b/project/templates/index.html
@@ -4,9 +4,9 @@
 <header class="container-fluid">
     <div class="navbar-nav bd-navbar-nav flex-row row align-items-center">
         <a href="index.html"><h1 class="col">My Blog</h1></a>
-        <div class="col-4" align="left">{%if username%} You are logged as {{username}} {%endif%}</div>
+        <div class="col-4" align="left">{%if current_user.is_authenticated %} You are logged as {{ current_user.username }} {%endif%}</div>
         <ul class="col-6 row justify-content-end">
-            {% if is_authed%}
+            {% if current_user.is_authenticated %}
             <li class="btn btn-secondary border"><a href="new_post.html">New Post</a></li>
             <li class="btn btn-secondary border"><a href="logout/">Log Out</a></li>
             {% else %}


### PR DESCRIPTION
Проблема запуска заключалась в том, что был использован готовый образ `tiangolo/uwsgi-nginx-flask`. Там запуск автоматически идёт через entrypoint и start скрипты. Для того, чтобы сделать свой entrypoint, недостаточно просто заменить существующий. Чтобы всё работало, нужно оставить их entrypoint, в котором идёт предварительная настройка uwsgi, nginx, а сверху добавить свой (с созданием моделей).

Самый простой способ это сделать: внутри нашего entrypoint вызвать их скрипт, а затем выполнить нужные нам команды. Поэтому переименовываем их энтрипоинт, затем приносим свой (где уже есть вызов их энтрипоинта) и дальше вызываем их start скрипт (если не указать, ничего не запустится)

___
Для работы с сессией нужен `SECRET_KEY` (название было перепутано, использовался `API_KEY`)

Также поправил обращение к айди и юзернейму пользователя. Они доступны через `current_user`, не нужно это складывать в сессию, только если нам нужно будет получить юзернейм и айди не текущего пользователя, а последнего. кто был в этом браузере

___
Ещё выпилил излишнюю проверку юзера на авторизованность. Оставил проверку только в темплейте (см изменения `index.html`)